### PR TITLE
feat: allow guest access with landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect, createContext, useContext } from "react";
+import React, { useMemo, useState, createContext, useContext } from "react";
 
 /**
  * Signup UI con toast successo/errore e redirect automatico alla piattaforma.

--- a/src/app/features/auth/Signup.tsx
+++ b/src/app/features/auth/Signup.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, createContext, useContext } from "react";
+import React, { useState, createContext, useContext } from "react";
 
 const PLATFORM_URL = "/app/me";
 const REDIRECT_DELAY_MS = 1000;

--- a/src/app/features/home/AppLanding.tsx
+++ b/src/app/features/home/AppLanding.tsx
@@ -1,0 +1,100 @@
+import { Link, Navigate } from "react-router-dom";
+import { useSession } from "@/app/features/auth/useSession";
+
+const DASHBOARD_ROUTE = "/app/me";
+const DEFAULT_ROLE_REDIRECTS = new Set(["CANDIDATE", "EMPLOYER", "ADMIN"]);
+
+export default function AppLanding() {
+  const { account } = useSession();
+  const roles = new Set(account?.roles ?? []);
+  const hasKnownRole = Array.from(DEFAULT_ROLE_REDIRECTS).some((role) => roles.has(role));
+
+  if (account && hasKnownRole) {
+    return <Navigate to={DASHBOARD_ROUTE} replace />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-3xl border bg-white p-6 shadow-sm">
+        <h1 className="text-3xl font-semibold tracking-tight">Benvenuto in TalentALB</h1>
+        <p className="mt-3 max-w-2xl text-gray-600">
+          Accedi all&apos;anteprima della piattaforma anche senza un account: esplora le funzionalità, consulta la
+          ricerca talenti e scopri come gestire le candidature. Quando sarai pronto potrai creare l&apos;account in
+          qualsiasi momento.
+        </p>
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <Link
+            to="/auth/signup"
+            className="rounded-2xl bg-black px-5 py-2 text-sm font-medium text-white shadow transition hover:bg-black/90"
+          >
+            Crea un account
+          </Link>
+          <Link
+            to="/app/search"
+            className="rounded-2xl border border-gray-200 px-5 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50"
+          >
+            Inizia ad esplorare
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <FeatureCard
+          title="Per i candidati"
+          description="Compila il profilo, carica CV e allegati e gestisci le candidature in maniera semplice."
+          actionLabel="Guarda il profilo demo"
+          to="/app/candidate"
+          disabled={!account}
+        />
+        <FeatureCard
+          title="Per le aziende"
+          description="Crea e gestisci il tuo profilo aziendale, invita i recruiter e pubblica le offerte di lavoro."
+          actionLabel="Scopri l&apos;area azienda"
+          to="/app/company"
+          disabled={!account}
+        />
+      </section>
+
+      <section className="rounded-3xl border bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold">Candidati solo quando vuoi</h2>
+        <p className="mt-2 text-gray-600">
+          Stai navigando come ospite. Quando vorrai candidarti ad una posizione o salvare le tue preferenze ti
+          chiederemo di registrarti. Fino ad allora puoi continuare a muoverti liberamente nella piattaforma.
+        </p>
+        <Link
+          to="/auth/signup"
+          className="mt-4 inline-flex rounded-2xl bg-black px-5 py-2 text-sm font-medium text-white shadow transition hover:bg-black/90"
+        >
+          Registrati ora
+        </Link>
+      </section>
+    </div>
+  );
+}
+
+function FeatureCard({
+  title,
+  description,
+  actionLabel,
+  to,
+  disabled,
+}: {
+  title: string;
+  description: string;
+  actionLabel: string;
+  to: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="rounded-2xl border bg-white p-6 shadow-sm">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="mt-2 text-sm text-gray-600">{description}</p>
+      <Link
+        to={disabled ? "/auth/signup" : to}
+        className="mt-4 inline-flex rounded-2xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-800 transition hover:bg-gray-50"
+      >
+        {disabled ? "Registrati per continuare" : actionLabel}
+      </Link>
+    </div>
+  );
+}

--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -4,6 +4,7 @@ import { getSessionAccount, clearSessionAccount } from "@/app/features/auth/useS
 export default function AppShell() {
   const acc = getSessionAccount();
   const roles = new Set(acc?.roles ?? []);
+  const isGuest = !acc;
 
   const candidateMenu = [
     { to: "/app/candidate", label: "Dashboard" },
@@ -19,29 +20,52 @@ export default function AppShell() {
   ];
   const commonMenu = [
     { to: "/app/search", label: "Cerca talenti" },
-    { to: "/app/settings", label: "Impostazioni" },
+    ...(!isGuest ? [{ to: "/app/settings", label: "Impostazioni" }] : []),
   ];
 
   return (
     <div className="min-h-screen grid grid-cols-[240px_1fr]">
       <aside className="border-r bg-white p-4">
-        <div className="mb-6">
+        <div className="mb-6 space-y-1">
           <div className="font-bold">TalentALB</div>
-          <div className="text-xs text-gray-500 break-all">{acc?.email}</div>
+          <div className="text-xs text-gray-500 break-all">
+            {acc?.email ?? "Accesso come ospite"}
+          </div>
         </div>
         <nav className="space-y-1">
           {roles.has("CANDIDATE") && candidateMenu.map((m) => <Item key={m.to} {...m} />)}
           {roles.has("EMPLOYER")  && companyMenu.map((m) => <Item key={m.to} {...m} />)}
-          <div className="pt-2 border-t mt-2">{commonMenu.map((m) => <Item key={m.to} {...m} />)}</div>
-          <button
-            onClick={() => { clearSessionAccount(); window.location.href = "/auth/signup"; }}
-            className="mt-4 text-left w-full rounded-xl px-3 py-2 text-sm hover:bg-gray-50"
-          >
-            Logout
-          </button>
+          <div className="pt-2 mt-2 space-y-1 border-t">
+            {commonMenu.map((m) => (
+              <Item key={m.to} {...m} />
+            ))}
+          </div>
+          {!isGuest && (
+            <button
+              onClick={() => {
+                clearSessionAccount();
+                window.location.href = "/app";
+              }}
+              className="mt-4 w-full rounded-xl px-3 py-2 text-left text-sm hover:bg-gray-50"
+            >
+              Logout
+            </button>
+          )}
         </nav>
       </aside>
       <main className="p-6">
+        {isGuest && (
+          <div className="mb-6 flex justify-end">
+            <button
+              onClick={() => {
+                window.location.href = "/auth/signup";
+              }}
+              className="rounded-2xl bg-black px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-black/90"
+            >
+              Iscriviti ora
+            </button>
+          </div>
+        )}
         <Outlet />
       </main>
     </div>

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,4 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
-// router.tsx (e ovunque serva)
 import Signup from "@/app/features/auth/Signup";
 import AppShell from "@/app/layouts/AppShell";
 import CandidateDashboard from "@/app/features/candidate/pages/Dashboard";
@@ -7,49 +6,49 @@ import CandidateProfileEdit from "@/app/features/candidate/pages/ProfileEdit";
 import CompanyDashboard from "@/app/features/company/pages/Dashboard";
 import CompanyProfileEdit from "@/app/features/company/pages/CompanyProfileEdit";
 import TalentSearch from "@/app/features/search/pages/TalentSearch";
+import AppLanding from "@/app/features/home/AppLanding";
 import { ProtectedRoute, RoleSwitch } from "@/shared/components/Guard";
 
 export const router = createBrowserRouter([
-  { path: "/", element: <Navigate to="/auth/signup" replace /> },
+  { path: "/", element: <Navigate to="/app" replace /> },
   { path: "/auth/signup", element: <Signup /> },
-
   {
     path: "/app",
-    element: (
-      <ProtectedRoute>
-        <AppShell />
-      </ProtectedRoute>
-    ),
+    element: <AppShell />,
     children: [
-      { path: "", element: <Navigate to="me" replace /> },
-      {
-        path: "me",
-        element: (
-          <RoleSwitch
-            candidate={<Navigate to="/app/candidate" replace />}
-            employer={<Navigate to="/app/company" replace />}
-            admin={<Navigate to="/app/company" replace />}
-          />
-        ),
-      },
-
-      // Candidate
-      { path: "candidate", element: <CandidateDashboard /> },
-      { path: "candidate/profile", element: <CandidateProfileEdit /> },
-      { path: "candidate/attachments", element: <div>CV & Allegati (coming soon)</div> },
-      { path: "candidate/skills", element: <div>Competenze (coming soon)</div> },
-
-      // Company
-      { path: "company", element: <CompanyDashboard /> },
-      { path: "company/profile", element: <CompanyProfileEdit /> },
-      { path: "company/users", element: <div>Utenti azienda (coming soon)</div> },
-      { path: "company/jobs", element: <div>Offerte di lavoro (coming soon)</div> },
-
-      // Common
+      { index: true, element: <AppLanding /> },
       { path: "search", element: <TalentSearch /> },
-      { path: "settings", element: <div>Impostazioni account (coming soon)</div> },
+      {
+        element: <ProtectedRoute />,
+        children: [
+          {
+            path: "me",
+            element: (
+              <RoleSwitch
+                candidate={<Navigate to="/app/candidate" replace />}
+                employer={<Navigate to="/app/company" replace />}
+                admin={<Navigate to="/app/company" replace />}
+              />
+            ),
+          },
+
+          // Candidate
+          { path: "candidate", element: <CandidateDashboard /> },
+          { path: "candidate/profile", element: <CandidateProfileEdit /> },
+          { path: "candidate/attachments", element: <div>CV & Allegati (coming soon)</div> },
+          { path: "candidate/skills", element: <div>Competenze (coming soon)</div> },
+
+          // Company
+          { path: "company", element: <CompanyDashboard /> },
+          { path: "company/profile", element: <CompanyProfileEdit /> },
+          { path: "company/users", element: <div>Utenti azienda (coming soon)</div> },
+          { path: "company/jobs", element: <div>Offerte di lavoro (coming soon)</div> },
+
+          // Common (authed only)
+          { path: "settings", element: <div>Impostazioni account (coming soon)</div> },
+        ],
+      },
     ],
   },
-
   { path: "*", element: <div className="p-6">Not Found</div> },
 ]);


### PR DESCRIPTION
## Summary
- add a guest landing page in the app area with calls to action for signup and exploration
- reorganize the router so `/app` is accessible to visitors while still guarding authenticated areas
- update the app shell to show guest messaging and an always-available signup button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e4347170832cb1741c4d8c63a08a