### PR TITLE
feat: refresh app shell UI and expose job board language switch

### DIFF
--- a/src/app/features/home/AppLanding.tsx
+++ b/src/app/features/home/AppLanding.tsx
@@ -5,6 +5,11 @@ import { useTranslations } from "@/shared/i18n/I18nProvider";
 const DASHBOARD_ROUTE = "/app/me";
 const DEFAULT_ROLE_REDIRECTS = new Set(["CANDIDATE", "EMPLOYER", "ADMIN"]);
 
+const primaryButtonClasses =
+  "inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-sm transition-transform duration-150 hover:-translate-y-0.5 hover:bg-slate-800";
+const secondaryButtonClasses =
+  "inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-transform duration-150 hover:-translate-y-0.5 hover:bg-slate-50";
+
 export default function AppLanding() {
   const { account } = useSession();
   const t = useTranslations();
@@ -16,27 +21,26 @@ export default function AppLanding() {
   }
 
   return (
-    <div className="space-y-6">
-      <section className="rounded-3xl border bg-white p-6 shadow-sm">
-        <h1 className="text-3xl font-semibold tracking-tight">{t("landing.welcomeTitle")}</h1>
-        <p className="mt-3 max-w-2xl text-gray-600">{t("landing.welcomeDescription")}</p>
-        <div className="mt-5 flex flex-wrap items-center gap-3">
-          <Link
-            to="/auth/signup"
-            className="rounded-2xl bg-black px-5 py-2 text-sm font-medium text-white shadow transition hover:bg-black/90"
-          >
+    <div className="space-y-8 text-slate-900">
+      <section className="rounded-3xl border border-slate-200 bg-white/80 px-6 py-10 text-center shadow-xl shadow-slate-900/5 backdrop-blur supports-[backdrop-filter]:bg-white/70 sm:px-10">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
+          {t("landing.eyebrow")}
+        </p>
+        <h1 className="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">{t("landing.welcomeTitle")}</h1>
+        <p className="mt-4 mx-auto max-w-2xl text-sm leading-relaxed text-slate-600 sm:text-base">
+          {t("landing.welcomeDescription")}
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <Link to="/auth/signup" className={primaryButtonClasses}>
             {t("common.actions.createAccount")}
           </Link>
-          <Link
-            to="/app/search"
-            className="rounded-2xl border border-gray-200 px-5 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50"
-          >
+          <Link to="/app/search" className={secondaryButtonClasses}>
             {t("common.actions.explore")}
           </Link>
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2">
+      <section className="grid gap-6 md:grid-cols-2">
         <FeatureCard
           title={t("landing.candidates.title")}
           description={t("landing.candidates.description")}
@@ -55,13 +59,12 @@ export default function AppLanding() {
         />
       </section>
 
-      <section className="rounded-3xl border bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold">{t("landing.guest.title")}</h2>
-        <p className="mt-2 text-gray-600">{t("landing.guest.description")}</p>
-        <Link
-          to="/auth/signup"
-          className="mt-4 inline-flex rounded-2xl bg-black px-5 py-2 text-sm font-medium text-white shadow transition hover:bg-black/90"
-        >
+      <section className="rounded-3xl border border-slate-200 bg-white/80 px-6 py-8 shadow-xl shadow-slate-900/5 backdrop-blur supports-[backdrop-filter]:bg-white/70 sm:px-8">
+        <h2 className="text-xl font-semibold tracking-tight">{t("landing.guest.title")}</h2>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600 sm:text-base">
+          {t("landing.guest.description")}
+        </p>
+        <Link to="/auth/signup" className={`${primaryButtonClasses} mt-4 w-fit`}>
           {t("common.actions.registerNow")}
         </Link>
       </section>
@@ -85,12 +88,14 @@ function FeatureCard({
   disabled?: boolean;
 }) {
   return (
-    <div className="rounded-2xl border bg-white p-6 shadow-sm">
-      <h3 className="text-lg font-semibold">{title}</h3>
-      <p className="mt-2 text-sm text-gray-600">{description}</p>
+    <div className="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-sm shadow-slate-900/5 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <h3 className="text-lg font-semibold tracking-tight text-slate-900">{title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-slate-600">{description}</p>
       <Link
         to={disabled ? "/auth/signup" : to}
-        className="mt-4 inline-flex rounded-2xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-800 transition hover:bg-gray-50"
+        className={`${secondaryButtonClasses} mt-4 w-fit ${
+          disabled ? "border-dashed text-slate-400 hover:-translate-y-0" : ""
+        }`}
       >
         {disabled ? disabledLabel : actionLabel}
       </Link>

--- a/src/features/job-board/JobBoardPage.tsx
+++ b/src/features/job-board/JobBoardPage.tsx
@@ -9,6 +9,7 @@ import {
   type TextareaHTMLAttributes,
 } from "react";
 import { Link } from "react-router-dom";
+import { LanguageSwitcher } from "@/shared/i18n/LanguageSwitcher";
 import { useI18n, useTranslations, type TranslateFn } from "@/shared/i18n/I18nProvider";
 import { localeConfig } from "@/shared/i18n/localeConfig";
 
@@ -210,24 +211,31 @@ export default function JobBoardPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-stone-50 via-white to-stone-100 text-slate-900">
       <header className="sticky top-0 z-30 border-b border-slate-100 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4">
+        <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-4 py-4">
           <Link to="/" className="text-base font-semibold tracking-tight text-slate-900">
             {t("common.appName")}
           </Link>
-          <nav className="flex items-center gap-2 text-sm text-slate-600">
-            <a href="#jobs" className={`${ghostButtonClasses} px-3 py-2`}>
-              {t("jobBoard.nav.offers")}
-            </a>
-            <a href="#candidature" className={`${ghostButtonClasses} px-3 py-2`}>
-              {t("jobBoard.nav.applications")}
-            </a>
-            <Link to="/auth/signup" className={`${secondaryButtonClasses} px-3 py-2`}>
-              {t("common.actions.createProfile")}
-            </Link>
-            <Link to="/app" className={`${primaryButtonClasses} px-3 py-2`}>
-              {t("common.actions.signIn")}
-            </Link>
-          </nav>
+          <div className="flex flex-1 flex-wrap items-center justify-end gap-3 sm:flex-none">
+            <nav className="order-1 flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600 sm:order-none">
+              <a href="#jobs" className={`${ghostButtonClasses} px-3 py-2`}>
+                {t("jobBoard.nav.offers")}
+              </a>
+              <a href="#candidature" className={`${ghostButtonClasses} px-3 py-2`}>
+                {t("jobBoard.nav.applications")}
+              </a>
+              <Link to="/auth/signup" className={`${secondaryButtonClasses} px-3 py-2`}>
+                {t("common.actions.createProfile")}
+              </Link>
+              <Link to="/app" className={`${primaryButtonClasses} px-3 py-2`}>
+                {t("common.actions.signIn")}
+              </Link>
+            </nav>
+            <LanguageSwitcher
+              hideLabel
+              className="order-2 w-full sm:order-none sm:w-auto"
+              selectClassName="mt-0 w-full rounded-full border border-slate-200 bg-white px-4 py-1.5 text-xs font-semibold text-slate-600 shadow-sm focus:border-slate-400 focus:ring-2 focus:ring-slate-200 sm:w-36"
+            />
+          </div>
         </div>
       </header>
 

--- a/src/shared/i18n/LanguageSwitcher.tsx
+++ b/src/shared/i18n/LanguageSwitcher.tsx
@@ -9,21 +9,44 @@ const OPTION_LABEL_KEYS: Record<Locale, TranslationKey> = {
   sq: "common.language.options.sq",
 };
 
-export function LanguageSwitcher({ className }: { className?: string }) {
+type LanguageSwitcherProps = {
+  className?: string;
+  /**
+   * Additional classes applied to the underlying <select> element.
+   * Useful to adapt the switcher to different layouts while keeping
+   * the same behaviour and accessibility.
+   */
+  selectClassName?: string;
+  /**
+   * When true the visual label is hidden but remains available for
+   * screen readers. Ideal for compact headers.
+   */
+  hideLabel?: boolean;
+};
+
+export function LanguageSwitcher({ className, selectClassName, hideLabel = false }: LanguageSwitcherProps) {
   const { locale, setLocale, t } = useI18n();
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     setLocale(event.target.value as Locale);
   };
 
+  const selectClasses = [
+    "mt-1 w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10",
+    hideLabel && "mt-0",
+    selectClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <label className={className}>
-      <span className="block text-xs font-medium text-gray-500">{t("common.language.label")}</span>
-      <select
-        value={locale}
-        onChange={handleChange}
-        className="mt-1 w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10"
-      >
+      {hideLabel ? (
+        <span className="sr-only">{t("common.language.label")}</span>
+      ) : (
+        <span className="block text-xs font-medium text-gray-500">{t("common.language.label")}</span>
+      )}
+      <select value={locale} onChange={handleChange} className={selectClasses}>
         {SUPPORTED_LOCALES.map((value) => (
           <option key={value} value={value}>
             {t(OPTION_LABEL_KEYS[value])}

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -49,6 +49,7 @@ export const en = {
     },
   },
   landing: {
+    eyebrow: "Platform preview",
     welcomeTitle: "Welcome to TalentALB",
     welcomeDescription:
       "Access the preview of the platform even without an account: explore features, browse the talent search and discover how to manage applications. When you're ready you can create your account at any time.",
@@ -86,6 +87,11 @@ export const en = {
         search: "Search talents",
         settings: "Settings",
       },
+    },
+    sections: {
+      candidate: "Candidate area",
+      company: "Company area",
+      common: "Platform",
     },
     session: {
       guest: "Browsing as guest",

--- a/src/shared/i18n/locales/it.ts
+++ b/src/shared/i18n/locales/it.ts
@@ -48,6 +48,7 @@ export const it = {
 
   },
   landing: {
+    eyebrow: "Anteprima piattaforma",
     welcomeTitle: "Benvenuto in TalentALB",
     welcomeDescription:
       "Accedi all'anteprima della piattaforma anche senza un account: esplora le funzionalità, consulta la ricerca talenti e scopri come gestire le candidature. Quando sarai pronto potrai creare l'account in qualsiasi momento.",
@@ -85,6 +86,11 @@ export const it = {
         search: "Cerca talenti",
         settings: "Impostazioni",
       },
+    },
+    sections: {
+      candidate: "Area candidato",
+      company: "Area azienda",
+      common: "Area piattaforma",
     },
     session: {
       guest: "Accesso come ospite",

--- a/src/shared/i18n/locales/sq.ts
+++ b/src/shared/i18n/locales/sq.ts
@@ -50,6 +50,7 @@ export const sq = {
 
   },
   landing: {
+    eyebrow: "Paraqitje e platformës",
     welcomeTitle: "Mirë se erdhe në TalentALB",
     welcomeDescription:
       "Hyr në pamjen paraprake të platformës edhe pa llogari: eksploro funksionalitetet, kërko talentë dhe zbulo si të menaxhosh aplikimet. Kur të jesh gati mund të krijosh llogarinë kur të duash.",
@@ -87,6 +88,11 @@ export const sq = {
         search: "Kërko talentë",
         settings: "Cilësimet",
       },
+    },
+    sections: {
+      candidate: "Zona e kandidatit",
+      company: "Zona e kompanisë",
+      common: "Platforma",
     },
     session: {
       guest: "Po shfleton si vizitor",


### PR DESCRIPTION
## Summary
- add the shared language selector to the job board header with a compact presentation
- restyle the /app shell and landing cards to mirror the job board look & feel
- extend the language switcher component and i18n messages to support the new layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f2625cb8832cb13382a1a98fa8ce