### PR TITLE
Fix job board dialog types and adjust navigation

### DIFF
--- a/src/features/job-board/JobBoardPage.tsx
+++ b/src/features/job-board/JobBoardPage.tsx
@@ -12,7 +12,7 @@ import { Link } from "react-router-dom";
 import { LanguageSwitcher } from "@/shared/i18n/LanguageSwitcher";
 import { useI18n, useTranslations, type TranslateFn } from "@/shared/i18n/I18nProvider";
 import { localeConfig } from "@/shared/i18n/localeConfig";
-import { JobApplication, useJobApplicationsStorage } from "@/features/job-board/useJobApplicationsStorage";
+import { useJobApplicationsStorage, type JobApplication } from "@/features/job-board/useJobApplicationsStorage";
 
 type JobPostDto = {
   id: string;
@@ -59,6 +59,12 @@ type ApplicationFormState = {
   phone: string;
   resumeUrl: string;
   message: string;
+};
+
+type ApplicationDialogProps = {
+  job: JobPostDto | null;
+  onClose: () => void;
+  onSubmit: (form: ApplicationFormState) => void;
 };
 
 const PAGE_SIZE = 6;
@@ -240,9 +246,6 @@ export default function JobBoardPage() {
             <nav className="order-1 flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600 sm:order-none">
               <a href="#jobs" className={`${ghostButtonClasses} px-3 py-2`}>
                 {t("jobBoard.nav.offers")}
-              </a>
-              <a href="#candidature" className={`${ghostButtonClasses} px-3 py-2`}>
-                {t("jobBoard.nav.applications")}
               </a>
               <Link to="/auth/signup" className={`${secondaryButtonClasses} px-3 py-2`}>
                 {t("common.actions.createProfile")}


### PR DESCRIPTION
## Summary
- add the missing ApplicationDialogProps definition to satisfy TypeScript
- use a type-only import for JobApplication to respect verbatimModuleSyntax
- remove the applications anchor from the job board header now that the list lives in the candidate area

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de28313a4c832c9b4ef1fbd212b226