### PR TITLE
Polish job creation flow and language switcher

### DIFF
--- a/src/app/features/company/pages/JobPostCreate.tsx
+++ b/src/app/features/company/pages/JobPostCreate.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
 import { getSessionAccount } from "@/app/features/auth/useSession";
 import { useTranslations } from "@/shared/i18n/I18nProvider";
 
@@ -8,7 +9,6 @@ type Seniority = "INTERN" | "JUNIOR" | "MID" | "SENIOR" | "LEAD";
 type DistanceType = "ONSITE" | "HYBRID" | "REMOTE";
 
 type CreateJobPostForm = {
-  companyId: string;
   title: string;
   description: string;
   requirements: string;
@@ -56,9 +56,12 @@ function parseDecimal(value: string): number | undefined {
 export default function JobPostCreate() {
   const t = useTranslations();
   const account = useMemo(() => getSessionAccount(), []);
+  const derivedCompanyId = useMemo(() => {
+    const directId = (account?.companyId as string | undefined) ||
+      ((account?.company as { id?: string } | undefined)?.id ?? "");
+    return directId?.trim() ?? "";
+  }, [account]);
   const [form, setForm] = useState<CreateJobPostForm>({
-    companyId: (account?.companyId as string | undefined) ||
-      ((account?.company as { id?: string } | undefined)?.id ?? ""),
     title: "",
     description: "",
     requirements: "",
@@ -84,7 +87,7 @@ export default function JobPostCreate() {
     setResult(null);
 
     try {
-      if (!form.companyId.trim()) {
+      if (!derivedCompanyId) {
         throw new Error(t("companyJobs.validation.companyId"));
       }
       if (!form.title.trim()) {
@@ -95,7 +98,7 @@ export default function JobPostCreate() {
       }
 
       const payload = {
-        companyId: form.companyId.trim(),
+        companyId: derivedCompanyId,
         title: form.title.trim(),
         description: form.description.trim(),
         requirements: form.requirements.trim() || undefined,
@@ -134,8 +137,6 @@ export default function JobPostCreate() {
 
   function resetForm() {
     setForm({
-      companyId: (account?.companyId as string | undefined) ||
-        ((account?.company as { id?: string } | undefined)?.id ?? ""),
       title: "",
       description: "",
       requirements: "",
@@ -156,23 +157,37 @@ export default function JobPostCreate() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{t("companyJobs.title")}</h1>
-        <p className="mt-1 text-sm text-slate-600">{t("companyJobs.description")}</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{t("companyJobs.title")}</h1>
+          <p className="mt-1 text-sm text-slate-600">{t("companyJobs.description")}</p>
+        </div>
+        <Link
+          to="/app"
+          className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition-transform duration-150 hover:-translate-y-0.5 hover:bg-slate-50 hover:text-slate-900"
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M11.78 5.22a.75.75 0 0 0-1.06 0L6.22 9.72a.75.75 0 0 0 0 1.06l4.5 4.5a.75.75 0 1 0 1.06-1.06L8.81 10l2.97-2.97a.75.75 0 0 0 0-1.06Z"
+              fill="currentColor"
+            />
+            <path
+              d="M5.75 10c0-.414.336-.75.75-.75h6.75a.75.75 0 0 1 0 1.5H6.5a.75.75 0 0 1-.75-.75Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>{t("common.actions.goBack")}</span>
+        </Link>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-5">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
-            {t("companyJobs.form.companyId")}
-            <input
-              className={baseFieldClasses}
-              value={form.companyId}
-              onChange={(e) => setForm((prev) => ({ ...prev, companyId: e.target.value }))}
-              placeholder="00000000-0000-0000-0000-000000000000"
-              required
-            />
-          </label>
           <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
             {t("companyJobs.form.title")}
             <input

--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -51,8 +51,9 @@ export default function AppShell() {
               </p>
             </div>
             <LanguageSwitcher
-              className="mt-6 w-full"
-              selectClassName="rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+              hideLabel
+              className="mt-6 ml-auto"
+              selectClassName="bg-slate-50 hover:bg-white"
             />
             <nav className="mt-6 space-y-6 text-sm">
               {sections.map((section) => (

--- a/src/features/job-board/JobBoardPage.tsx
+++ b/src/features/job-board/JobBoardPage.tsx
@@ -343,7 +343,7 @@ export default function JobBoardPage() {
               {/* Quick refine controls */}
               <div className="mt-3 flex flex-wrap items-center gap-4">
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{t("jobBoard.filters.workMode")}</span>
+                  <span className="text-xs font-semibold tracking-wide text-slate-500">{t("jobBoard.filters.workMode")}</span>
                   <div className="flex gap-1">
                     {optionsFromJobs.modes.map((m) => (
                       <button
@@ -359,7 +359,7 @@ export default function JobBoardPage() {
                 </div>
                 
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{t("jobBoard.filters.seniority")}</span>
+                  <span className="text-xs font-semibold tracking-wide text-slate-500">{t("jobBoard.filters.seniority")}</span>
                   <Dropdown
                     options={[
                       { value: "", label: t("jobBoard.filters.all") },
@@ -376,7 +376,7 @@ export default function JobBoardPage() {
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{t("jobBoard.filters.employmentType")}</span>
+                  <span className="text-xs font-semibold tracking-wide text-slate-500">{t("jobBoard.filters.employmentType")}</span>
                   <Dropdown
                     options={[
                       { value: "", label: t("jobBoard.filters.allTypes") },
@@ -393,7 +393,7 @@ export default function JobBoardPage() {
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{t("jobBoard.filters.sortBy")}</span>
+                  <span className="text-xs font-semibold tracking-wide text-slate-500">{t("jobBoard.filters.sortBy")}</span>
                   <Dropdown
                     options={[
                       { value: "relevance", label: t("jobBoard.filters.relevance") },

--- a/src/shared/i18n/LanguageSwitcher.tsx
+++ b/src/shared/i18n/LanguageSwitcher.tsx
@@ -2,6 +2,10 @@ import { useI18n } from "./I18nProvider";
 import type { Locale, TranslationKey } from "./messages";
 import { useState, useEffect, useRef } from "react";
 
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
 const SUPPORTED_LOCALES: Locale[] = ["it", "en", "sq"];
 const OPTION_LABEL_KEYS: Record<Locale, TranslationKey> = {
   it: "common.language.options.it",
@@ -12,9 +16,9 @@ const OPTION_LABEL_KEYS: Record<Locale, TranslationKey> = {
 type LanguageSwitcherProps = {
   className?: string;
   /**
-   * Additional classes applied to the underlying <select> element.
-   * Useful to adapt the switcher to different layouts while keeping
-   * the same behaviour and accessibility.
+   * Additional classes applied to the trigger button. Useful to adapt
+   * the switcher to different layouts while keeping the same behaviour
+   * and accessibility.
    */
   selectClassName?: string;
   /**
@@ -29,14 +33,16 @@ type LanguageDropdownProps = {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  buttonClassName?: string;
 };
 
 function LanguageDropdown({
-                              options,
-                              value,
-                              onChange,
-                              className = "",
-                          }: LanguageDropdownProps) {
+  options,
+  value,
+  onChange,
+  className = "",
+  buttonClassName = "",
+}: LanguageDropdownProps) {
     const [isOpen, setIsOpen] = useState(false);
     const rootRef = useRef<HTMLDivElement | null>(null);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -90,69 +96,69 @@ function LanguageDropdown({
     };
 
     return (
-        <div ref={rootRef} className={`relative ${className}`}>
-            <button
-                ref={buttonRef}
-                type="button"
-                aria-haspopup="listbox"
-                aria-expanded={isOpen}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setIsOpen((o) => !o)}
-                className="h-9 w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-left text-xs font-semibold text-slate-600 shadow-sm transition-colors hover:border-slate-300 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
-            >
+    <div ref={rootRef} className={joinClasses("relative", className)}>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => setIsOpen((o) => !o)}
+        className={joinClasses(
+          "inline-flex min-h-[2rem] min-w-[3.5rem] items-center justify-between gap-2 rounded-full border border-slate-200 bg-white px-3 text-xs font-medium text-slate-600 shadow-sm transition-colors hover:border-slate-300 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200",
+          buttonClassName,
+        )}
+      >
         <span className="block truncate">
           {selectedOption ? selectedOption.label : "IT"}
         </span>
-                <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
-          <svg
-              className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
-              aria-hidden="true"
-              width="16"
-              height="16"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-          >
-            <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.17l3.71-2.94a.75.75 0 1 1 .94 1.16l-4.2 3.33a.75.75 0 0 1-.94 0l-4.2-3.33a.75.75 0 0 1 .02-1.16z" />
-          </svg>
-        </span>
-            </button>
+        <svg
+          className={joinClasses("h-4 w-4 text-slate-400 transition-transform", isOpen && "rotate-180")}
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.17l3.71-2.94a.75.75 0 1 1 .94 1.16l-4.2 3.33a.75.75 0 0 1-.94 0l-4.2-3.33a.75.75 0 0 1 .02-1.16z" />
+        </svg>
+      </button>
 
-            {isOpen && (
-                <div className="absolute z-[110] mt-1 w-full overflow-auto rounded-xl border border-slate-200 bg-white shadow-lg">
-                    <ul role="listbox" className="max-h-48 overflow-auto">
-                        {options.map((option) => (
-                            <li
-                                key={option.value}
-                                role="option"
-                                aria-selected={option.value === value}
-                            >
-                                <button
-                                    type="button"
-
-                                    onPointerDown={(e) => {
-                                        e.preventDefault();
-                                        handleSelect(option.value);
-                                    }}
-
-                                    onClick={(e) => e.stopPropagation()}
-                                    className={`w-full px-4 py-2 text-left text-xs hover:bg-slate-50 ${
-                                        option.value === value
-                                            ? "bg-slate-100 font-semibold text-slate-900"
-                                            : "text-slate-700"
-                                    }`}
-                                >
-                                    {option.label}
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-            )}
+      {isOpen && (
+        <div className="absolute right-0 z-[110] mt-1 w-full min-w-[8rem] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg">
+          <ul role="listbox" className="max-h-48 overflow-auto py-1">
+            {options.map((option) => (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={option.value === value}
+              >
+                <button
+                  type="button"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(option.value);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  className={joinClasses(
+                    "w-full px-4 py-2 text-left text-xs",
+                    option.value === value
+                      ? "bg-slate-100 font-semibold text-slate-900"
+                      : "text-slate-700 hover:bg-slate-50",
+                  )}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
-export function LanguageSwitcher({ className, hideLabel = false }: LanguageSwitcherProps) {
+export function LanguageSwitcher({ className, selectClassName, hideLabel = false }: LanguageSwitcherProps) {
   const { locale, setLocale, t } = useI18n();
 
   const options = SUPPORTED_LOCALES.map((value) => ({
@@ -165,7 +171,7 @@ export function LanguageSwitcher({ className, hideLabel = false }: LanguageSwitc
   };
 
   return (
-    <label className={className}>
+    <label className={joinClasses("inline-flex flex-col", hideLabel && "items-end", className)}>
       {hideLabel ? (
         <span className="sr-only">{t("common.language.label")}</span>
       ) : (
@@ -175,7 +181,8 @@ export function LanguageSwitcher({ className, hideLabel = false }: LanguageSwitc
         options={options}
         value={locale}
         onChange={handleChange}
-        className={hideLabel ? "mt-0" : "mt-1"}
+        className={hideLabel ? undefined : "mt-1"}
+        buttonClassName={selectClassName}
       />
     </label>
   );

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export const en = {
       receiveUpdates: "Get updates",
       clearFilters: "Clear filters",
       logout: "Log out",
+      goBack: "Back to home",
     },
     status: {
       publication: "Publication",
@@ -169,7 +170,7 @@ export const en = {
   companyJobs: {
     title: "Create a new job post",
     description:
-      "Send a POST to `/api/job-posts`: fill in the required fields, add optional details and click \"Create job\".",
+      "Share the essentials of the new role: complete the form and publish it for the right candidates.",
     form: {
       companyId: "Company ID",
       title: "Title",
@@ -205,7 +206,7 @@ export const en = {
       errorMessage: "Could not create the job.",
     },
     validation: {
-      companyId: "Please provide the company ID.",
+      companyId: "We couldn’t detect your company. Please sign in with a company profile and try again.",
       title: "Please enter a job title.",
       description: "Please add a description.",
     },

--- a/src/shared/i18n/locales/it.ts
+++ b/src/shared/i18n/locales/it.ts
@@ -19,6 +19,7 @@ export const it = {
       receiveUpdates: "Ricevi aggiornamenti",
       clearFilters: "Rimuovi filtri",
       logout: "Esci",
+      goBack: "Torna alla home",
     },
     status: {
       publication: "Pubblicazione",
@@ -168,7 +169,7 @@ export const it = {
   companyJobs: {
     title: "Crea una nuova offerta di lavoro",
     description:
-      "Invia una POST a `/api/job-posts`: compila i campi obbligatori, aggiungi i dettagli facoltativi e premi \"Crea offerta\".",
+      "Racconta i dettagli principali della nuova posizione: compila il form e pubblicala per i candidati giusti.",
     form: {
       companyId: "ID azienda",
       title: "Titolo",
@@ -204,7 +205,7 @@ export const it = {
       errorMessage: "Impossibile creare l'offerta.",
     },
     validation: {
-      companyId: "Inserisci l'ID aziendale.",
+      companyId: "Non riusciamo a rilevare la tua azienda. Accedi con un profilo aziendale e riprova.",
       title: "Inserisci il titolo dell'offerta.",
       description: "Aggiungi una descrizione.",
     },


### PR DESCRIPTION
## Summary
- automatically resolve the company associated with the logged-in account when creating job posts and remove the manual company ID field
- soften job board filter headings and refresh the company job copy to remove API instructions in both English and Italian
- restyle the shared language switcher for a more compact appearance inside the application shell

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68de368dfd1c832c85e066725bb9a263