### PR TITLE
Add login page and improve language controls

### DIFF
--- a/src/app/features/auth/AuthComponents.tsx
+++ b/src/app/features/auth/AuthComponents.tsx
@@ -1,0 +1,166 @@
+import React, { createContext, useContext, useState } from "react";
+import { useTranslations } from "@/shared/i18n/I18nProvider";
+
+export function cx(...parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+type ToastKind = "success" | "error" | "info";
+
+type ToastMessage = {
+  id: number;
+  kind: ToastKind;
+  title?: string;
+  message: string;
+  duration?: number;
+};
+
+const ToastContext = createContext<{ push: (toast: Omit<ToastMessage, "id">) => void } | null>(null);
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
+  return ctx;
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  const push = (toast: Omit<ToastMessage, "id">) => {
+    const id = Date.now() + Math.random();
+    const entry: ToastMessage = { id, duration: 3000, ...toast };
+    setToasts((prev) => [...prev, entry]);
+    setTimeout(() => setToasts((prev) => prev.filter((item) => item.id !== id)), entry.duration);
+  };
+
+  return (
+    <ToastContext.Provider value={{ push }}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 space-y-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={cx(
+              "w-80 rounded-2xl border p-3 shadow-lg backdrop-blur bg-white/95",
+              toast.kind === "success" && "border-green-200",
+              toast.kind === "error" && "border-red-200",
+              toast.kind === "info" && "border-gray-200"
+            )}
+          >
+            <div className="flex items-start gap-2">
+              <span
+                className={cx(
+                  "mt-1 inline-block h-2.5 w-2.5 rounded-full",
+                  toast.kind === "success" && "bg-green-500",
+                  toast.kind === "error" && "bg-red-500",
+                  toast.kind === "info" && "bg-gray-500"
+                )}
+              />
+              <div className="grow">
+                {toast.title && <div className="text-sm font-medium">{toast.title}</div>}
+                <div className="whitespace-pre-wrap text-sm text-gray-700">{toast.message}</div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+function Label({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) {
+  return (
+    <label htmlFor={htmlFor} className="mb-1 block text-sm font-medium text-gray-800">
+      {children}
+    </label>
+  );
+}
+
+function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={cx(
+        "w-full rounded-2xl border border-gray-200 bg-white p-3 shadow-sm",
+        "placeholder:text-gray-400 focus:border-black focus:outline-none focus:ring-2 focus:ring-black/80",
+        props.className || ""
+      )}
+    />
+  );
+}
+
+type FieldProps = { label: string; name: string } & React.InputHTMLAttributes<HTMLInputElement>;
+
+export function Field({ label, name, ...rest }: FieldProps) {
+  return (
+    <div>
+      <Label htmlFor={name}>{label}</Label>
+      <Input id={name} name={name} {...rest} />
+    </div>
+  );
+}
+
+type PasswordFieldProps = {
+  label: string;
+  showLabel: string;
+  hideLabel: string;
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  required?: boolean;
+};
+
+export function PasswordField({ label, showLabel, hideLabel, value, onChange, required }: PasswordFieldProps) {
+  const [show, setShow] = useState(false);
+  return (
+    <div>
+      <Label htmlFor="password">{label}</Label>
+      <div className="relative">
+        <Input
+          id="password"
+          name="password"
+          type={show ? "text" : "password"}
+          value={value}
+          onChange={onChange}
+          required={required}
+          className="pr-12"
+        />
+        <button
+          type="button"
+          onClick={() => setShow((prev) => !prev)}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+        >
+          {show ? hideLabel : showLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type SubmitButtonProps = {
+  loading: boolean;
+  children: React.ReactNode;
+  loadingLabel?: string;
+};
+
+export function SubmitButton({ loading, children, loadingLabel }: SubmitButtonProps) {
+  const t = useTranslations();
+  return (
+    <button
+      className={cx(
+        "mt-2 w-full rounded-2xl bg-black p-3 text-white shadow transition",
+        "disabled:cursor-not-allowed disabled:opacity-60 hover:bg-black/90"
+      )}
+      disabled={loading}
+      type="submit"
+    >
+      {loading ? (
+        <span className="inline-flex items-center gap-2">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          {loadingLabel ?? t("auth.signup.processing")}
+        </span>
+      ) : (
+        children
+      )}
+    </button>
+  );
+}

--- a/src/app/features/auth/Login.tsx
+++ b/src/app/features/auth/Login.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import { Link, Navigate } from "react-router-dom";
+import { useTranslations } from "@/shared/i18n/I18nProvider";
+import { LanguageSwitcher } from "@/shared/i18n/LanguageSwitcher";
+import { getSessionAccount } from "@/app/features/auth/useSession";
+import type { AccountDto } from "@/app/features/auth/types";
+import { postJson } from "@/app/features/auth/api";
+import {
+  ToastProvider,
+  useToast,
+  Field,
+  PasswordField,
+  SubmitButton,
+} from "@/app/features/auth/AuthComponents";
+
+const PLATFORM_URL = "/app/me";
+const REDIRECT_DELAY_MS = 1000;
+
+type LoginFormState = {
+  email: string;
+  password: string;
+};
+
+function LoginForm() {
+  const { push } = useToast();
+  const t = useTranslations();
+  const [form, setForm] = useState<LoginFormState>({ email: "", password: "" });
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      const payload = {
+        email: form.email.trim(),
+        password: form.password,
+      };
+      const account = await postJson<typeof payload, AccountDto>("/api/auth/login", payload);
+      localStorage.setItem("account", JSON.stringify(account));
+      push({
+        kind: "success",
+        title: t("auth.login.successTitle"),
+        message: t("auth.login.successBody"),
+      });
+      setTimeout(() => {
+        window.location.href = PLATFORM_URL;
+      }, REDIRECT_DELAY_MS);
+    } catch (err: any) {
+      push({
+        kind: "error",
+        title: t("auth.login.errorTitle"),
+        message: err?.message ?? String(err),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <Field
+        label={t("auth.login.fields.email")}
+        name="email"
+        type="email"
+        value={form.email}
+        onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+        required
+      />
+      <PasswordField
+        label={t("auth.login.fields.password")}
+        showLabel={t("auth.signup.passwordShow")}
+        hideLabel={t("auth.signup.passwordHide")}
+        value={form.password}
+        onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+        required
+      />
+      <SubmitButton loading={loading} loadingLabel={t("auth.login.processing")}>
+        {t("auth.login.submit")}
+      </SubmitButton>
+    </form>
+  );
+}
+
+export default function Login() {
+  const t = useTranslations();
+  const account = getSessionAccount();
+
+  if (account) {
+    return <Navigate to={PLATFORM_URL} replace />;
+  }
+
+  return (
+    <ToastProvider>
+      <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 text-gray-900">
+        <div className="mx-auto max-w-md p-6">
+          <header className="mb-8">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs text-gray-600">
+                  <span className="inline-block h-2 w-2 rounded-full bg-black" />
+                  {t("auth.login.badge")}
+                </div>
+                <h1 className="mt-3 text-3xl font-bold tracking-tight">{t("auth.login.title")}</h1>
+                <p className="text-sm text-gray-600">{t("auth.login.description")}</p>
+              </div>
+              <div className="flex flex-col items-end gap-2 sm:gap-3">
+                <LanguageSwitcher
+                  hideLabel
+                  className="ml-auto"
+                  selectClassName="bg-white px-4 py-1.5 text-xs font-semibold text-gray-600 shadow-sm border border-gray-200 hover:border-gray-300"
+                />
+                <Link
+                  to="/"
+                  className="text-xs font-semibold text-gray-600 underline-offset-4 hover:text-gray-900 hover:underline"
+                >
+                  {t("common.actions.goBack")}
+                </Link>
+              </div>
+            </div>
+          </header>
+
+          <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
+            <LoginForm />
+          </div>
+
+          <p className="mt-6 text-center text-xs text-gray-500">
+            {t("auth.login.footer.noAccount")} {" "}
+            <Link to="/auth/signup" className="font-semibold text-gray-700 hover:text-gray-900">
+              {t("auth.login.footer.signupLink")}
+            </Link>
+          </p>
+        </div>
+      </div>
+    </ToastProvider>
+  );
+}

--- a/src/app/features/auth/Signup.tsx
+++ b/src/app/features/auth/Signup.tsx
@@ -1,184 +1,47 @@
-import React, { useState, createContext, useContext } from "react";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { useTranslations } from "@/shared/i18n/I18nProvider";
+import { LanguageSwitcher } from "@/shared/i18n/LanguageSwitcher";
+import type { AccountDto } from "@/app/features/auth/types";
+import { postJson } from "@/app/features/auth/api";
+import {
+  ToastProvider,
+  useToast,
+  Field,
+  PasswordField,
+  SubmitButton,
+  cx,
+} from "@/app/features/auth/AuthComponents";
 
 const PLATFORM_URL = "/app/me";
 const REDIRECT_DELAY_MS = 1000;
 
-type UserRole = "CANDIDATE" | "EMPLOYER" | "ADMIN" | string;
-
-type AccountDto = {
-  id: string;
+type CandidateSignupReq = {
   email: string;
-  roles?: UserRole[];
-  [k: string]: unknown;
+  password: string;
+  firstName: string;
+  lastName: string;
+  city?: string;
 };
 
-async function postJson<TReq, TRes>(url: string, body: TReq): Promise<TRes> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`HTTP ${res.status} ${res.statusText}${text ? `\n${text}` : ""}`);
-  }
-  return (await res.json()) as TRes;
-}
-
-function cx(...p: Array<string | false | null | undefined>) {
-  return p.filter(Boolean).join(" ");
-}
-
-/* ---------------- Toast (no deps) ---------------- */
-type ToastKind = "success" | "error" | "info";
-type ToastMsg = { id: number; kind: ToastKind; title?: string; message: string; duration?: number };
-const ToastCtx = createContext<{ push: (t: Omit<ToastMsg, "id">) => void } | null>(null);
-export function useToast() {
-  const ctx = useContext(ToastCtx);
-  if (!ctx) throw new Error("useToast must be used within <ToastProvider>");
-  return ctx;
-}
-export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const [toasts, setToasts] = useState<ToastMsg[]>([]);
-  const push = (t: Omit<ToastMsg, "id">) => {
-    const id = Date.now() + Math.random();
-    const toast: ToastMsg = { id, duration: 3000, ...t };
-    setToasts((prev) => [...prev, toast]);
-    setTimeout(() => setToasts((prev) => prev.filter((x) => x.id !== id)), toast.duration);
-  };
-  return (
-    <ToastCtx.Provider value={{ push }}>
-      {children}
-      <div className="fixed top-4 right-4 z-50 space-y-2">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className={cx(
-              "w-80 rounded-2xl border p-3 shadow-lg backdrop-blur bg-white/95",
-              t.kind === "success" && "border-green-200",
-              t.kind === "error" && "border-red-200",
-              t.kind === "info" && "border-gray-200"
-            )}
-          >
-            <div className="flex items-start gap-2">
-              <span
-                className={cx(
-                  "mt-1 inline-block h-2.5 w-2.5 rounded-full",
-                  t.kind === "success" && "bg-green-500",
-                  t.kind === "error" && "bg-red-500",
-                  t.kind === "info" && "bg-gray-500"
-                )}
-              />
-              <div className="grow">
-                {t.title && <div className="text-sm font-medium">{t.title}</div>}
-                <div className="whitespace-pre-wrap text-sm text-gray-700">{t.message}</div>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </ToastCtx.Provider>
-  );
-}
-
-/* ---------------- UI primitives ---------------- */
-function Label({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) {
-  return (
-    <label htmlFor={htmlFor} className="mb-1 block text-sm font-medium text-gray-800">
-      {children}
-    </label>
-  );
-}
-
-function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <input
-      {...props}
-      className={cx(
-        "w-full rounded-2xl border border-gray-200 bg-white p-3 shadow-sm",
-        "placeholder:text-gray-400 focus:border-black focus:outline-none focus:ring-2 focus:ring-black/80",
-        props.className || ""
-      )}
-    />
-  );
-}
-
-function Field({ label, name, ...rest }: { label: string; name: string } & React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <div>
-      <Label htmlFor={name}>{label}</Label>
-      <Input id={name} name={name} {...rest} />
-    </div>
-  );
-}
-
-type PasswordFieldProps = {
-  label: string;
-  showLabel: string;
-  hideLabel: string;
-  value: string;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  required?: boolean;
+type CompanySignupReq = {
+  email: string;
+  password: string;
+  companyName: string;
+  website?: string;
+  city?: string;
 };
-
-function PasswordField({ label, showLabel, hideLabel, value, onChange, required }: PasswordFieldProps) {
-  const [show, setShow] = useState(false);
-  return (
-    <div>
-      <Label htmlFor="password">{label}</Label>
-      <div className="relative">
-        <Input
-          id="password"
-          name="password"
-          type={show ? "text" : "password"}
-          value={value}
-          onChange={onChange}
-          required={required}
-          className="pr-12"
-        />
-        <button
-          type="button"
-          onClick={() => setShow((s) => !s)}
-          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl border px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
-        >
-          {show ? hideLabel : showLabel}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function SubmitButton({ loading, children }: { loading: boolean; children: React.ReactNode }) {
-  const t = useTranslations();
-  return (
-    <button
-      className={cx(
-        "mt-2 w-full rounded-2xl bg-black p-3 text-white shadow transition",
-        "disabled:cursor-not-allowed disabled:opacity-60 hover:bg-black/90"
-      )}
-      disabled={loading}
-    >
-      {loading ? (
-        <span className="inline-flex items-center gap-2">
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-          {t("auth.signup.processing")}
-        </span>
-      ) : (
-        children
-      )}
-    </button>
-  );
-}
-
-/* ---------------- Forms ---------------- */
-type CandidateSignupReq = { email: string; password: string; firstName: string; lastName: string; city?: string };
-type CompanySignupReq = { email: string; password: string; companyName: string; website?: string; city?: string };
 
 function CandidateForm() {
   const { push } = useToast();
   const t = useTranslations();
-  const [form, setForm] = useState<CandidateSignupReq>({ email: "", password: "", firstName: "", lastName: "", city: "" });
+  const [form, setForm] = useState<CandidateSignupReq>({
+    email: "",
+    password: "",
+    firstName: "",
+    lastName: "",
+    city: "",
+  });
   const [loading, setLoading] = useState(false);
 
   function update<K extends keyof CandidateSignupReq>(key: K, value: string) {
@@ -261,7 +124,13 @@ function CandidateForm() {
 function CompanyForm() {
   const { push } = useToast();
   const t = useTranslations();
-  const [form, setForm] = useState<CompanySignupReq>({ email: "", password: "", companyName: "", website: "", city: "" });
+  const [form, setForm] = useState<CompanySignupReq>({
+    email: "",
+    password: "",
+    companyName: "",
+    website: "",
+    city: "",
+  });
   const [loading, setLoading] = useState(false);
 
   function update<K extends keyof CompanySignupReq>(key: K, value: string) {
@@ -350,12 +219,29 @@ export default function Signup() {
       <div className="min-h-screen bg-gradient-to-b from-white to-gray-50 text-gray-900">
         <div className="mx-auto max-w-md p-6">
           <header className="mb-8">
-            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs text-gray-600">
-              <span className="inline-block h-2 w-2 rounded-full bg-black" />
-              {t("auth.signup.badge")}
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs text-gray-600">
+                  <span className="inline-block h-2 w-2 rounded-full bg-black" />
+                  {t("auth.signup.badge")}
+                </div>
+                <h1 className="mt-3 text-3xl font-bold tracking-tight">{t("auth.signup.title")}</h1>
+                <p className="text-sm text-gray-600">{t("auth.signup.description")}</p>
+              </div>
+              <div className="flex flex-col items-end gap-2 sm:gap-3">
+                <LanguageSwitcher
+                  hideLabel
+                  className="ml-auto"
+                  selectClassName="bg-white px-4 py-1.5 text-xs font-semibold text-gray-600 shadow-sm border border-gray-200 hover:border-gray-300"
+                />
+                <Link
+                  to="/"
+                  className="text-xs font-semibold text-gray-600 underline-offset-4 hover:text-gray-900 hover:underline"
+                >
+                  {t("common.actions.goBack")}
+                </Link>
+              </div>
             </div>
-            <h1 className="mt-3 text-3xl font-bold tracking-tight">{t("auth.signup.title")}</h1>
-            <p className="text-sm text-gray-600">{t("auth.signup.description")}</p>
           </header>
 
           <div className="mb-4 flex rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
@@ -365,6 +251,7 @@ export default function Signup() {
                 "flex-1 rounded-xl px-4 py-2 text-sm transition",
                 tab === "candidate" ? "bg-black text-white shadow" : "hover:bg-gray-50"
               )}
+              type="button"
             >
               {t("auth.signup.tabs.candidate")}
             </button>
@@ -374,6 +261,7 @@ export default function Signup() {
                 "flex-1 rounded-xl px-4 py-2 text-sm transition",
                 tab === "company" ? "bg-black text-white shadow" : "hover:bg-gray-50"
               )}
+              type="button"
             >
               {t("auth.signup.tabs.company")}
             </button>
@@ -382,6 +270,13 @@ export default function Signup() {
           <div className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
             {tab === "candidate" ? <CandidateForm /> : <CompanyForm />}
           </div>
+
+          <p className="mt-6 text-center text-xs text-gray-500">
+            {t("auth.signup.footer.haveAccount")} {" "}
+            <Link to="/auth/login" className="font-semibold text-gray-700 hover:text-gray-900">
+              {t("auth.signup.footer.loginLink")}
+            </Link>
+          </p>
         </div>
       </div>
     </ToastProvider>

--- a/src/app/features/auth/api.ts
+++ b/src/app/features/auth/api.ts
@@ -1,0 +1,14 @@
+export async function postJson<TReq, TRes>(url: string, body: TReq): Promise<TRes> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status} ${res.statusText}${text ? `\n${text}` : ""}`);
+  }
+
+  return (await res.json()) as TRes;
+}

--- a/src/app/features/auth/types.ts
+++ b/src/app/features/auth/types.ts
@@ -1,0 +1,8 @@
+export type UserRole = "CANDIDATE" | "EMPLOYER" | "ADMIN" | string;
+
+export type AccountDto = {
+  id: string;
+  email: string;
+  roles?: UserRole[];
+  [k: string]: unknown;
+};

--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -42,19 +42,21 @@ export default function AppShell() {
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:flex-row lg:py-12">
         <aside className="lg:w-72">
           <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm lg:sticky lg:top-10 lg:max-h-[calc(100vh-5rem)] lg:overflow-y-auto">
-            <div className="space-y-2">
-              <span className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
-                {t("common.appName")}
-              </span>
-              <p className="break-all text-base font-semibold text-slate-900">
-                {acc?.email ?? t("appShell.session.guest")}
-              </p>
+            <div className="flex items-start gap-4">
+              <div className="space-y-2">
+                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+                  {t("common.appName")}
+                </span>
+                <p className="break-all text-base font-semibold text-slate-900">
+                  {acc?.email ?? t("appShell.session.guest")}
+                </p>
+              </div>
+              <LanguageSwitcher
+                hideLabel
+                className="ml-auto shrink-0"
+                selectClassName="bg-slate-50 hover:bg-white"
+              />
             </div>
-            <LanguageSwitcher
-              hideLabel
-              className="mt-6 ml-auto"
-              selectClassName="bg-slate-50 hover:bg-white"
-            />
             <nav className="mt-6 space-y-6 text-sm">
               {sections.map((section) => (
                 <NavSection key={section.title} title={section.title} items={section.items} />
@@ -77,6 +79,14 @@ export default function AppShell() {
           <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
             {isGuest && (
               <div className="mb-6 flex flex-wrap justify-end gap-3">
+                <button
+                  onClick={() => {
+                    window.location.href = "/auth/login";
+                  }}
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm transition-transform duration-150 hover:-translate-y-0.5 hover:bg-slate-50"
+                >
+                  {t("common.actions.signIn")}
+                </button>
                 <button
                   onClick={() => {
                     window.location.href = "/auth/signup";

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import Signup from "@/app/features/auth/Signup";
+import Login from "@/app/features/auth/Login";
 import AppShell from "@/app/layouts/AppShell";
 import CandidateDashboard from "@/app/features/candidate/pages/Dashboard";
 import CandidateProfileEdit from "@/app/features/candidate/pages/ProfileEdit";
@@ -16,6 +17,7 @@ import type { TranslationKey } from "@/shared/i18n/messages";
 export const router = createBrowserRouter([
   { path: "/", element: <JobBoardPage /> },
   { path: "/auth/signup", element: <Signup /> },
+  { path: "/auth/login", element: <Login /> },
   {
     path: "/app",
     element: <AppShell />,

--- a/src/features/job-board/JobBoardPage.tsx
+++ b/src/features/job-board/JobBoardPage.tsx
@@ -199,6 +199,10 @@ export default function JobBoardPage() {
   const handleResetFilters = () => {
     setFormState(DEFAULT_FILTERS);
     setActiveFilters(DEFAULT_FILTERS);
+    setWorkMode(null);
+    setSeniority(null);
+    setEmploymentType(null);
+    setSortBy("relevance");
     setPage(0);
   };
 
@@ -250,7 +254,7 @@ export default function JobBoardPage() {
               <Link to="/auth/signup" className={`${secondaryButtonClasses} px-3 py-2`}>
                 {t("common.actions.createProfile")}
               </Link>
-              <Link to="/app" className={`${primaryButtonClasses} px-3 py-2`}>
+              <Link to="/auth/login" className={`${primaryButtonClasses} px-3 py-2`}>
                 {t("common.actions.signIn")}
               </Link>
             </nav>

--- a/src/shared/components/Guard.tsx
+++ b/src/shared/components/Guard.tsx
@@ -4,7 +4,7 @@ import { getSessionAccount } from "@/app/features/auth/useSession";
 
 export function ProtectedRoute({ children }: { children?: React.ReactNode }) {
   const acc = getSessionAccount();
-  if (!acc) return <Navigate to="/auth/signup" replace />;
+  if (!acc) return <Navigate to="/auth/login" replace />;
   return <>{children ?? <Outlet />}</>;
 }
 

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -248,6 +248,28 @@ export const en = {
       passwordLabel: "Password",
       passwordShow: "Show",
       passwordHide: "Hide",
+      footer: {
+        haveAccount: "Already have an account?",
+        loginLink: "Sign in",
+      },
+    },
+    login: {
+      badge: "Auth · Sign in",
+      title: "Sign in to your account",
+      description: "Enter your credentials to continue.",
+      processing: "Signing you in…",
+      fields: {
+        email: "Email",
+        password: "Password",
+      },
+      submit: "Sign in",
+      successTitle: "Signed in",
+      successBody: "Welcome back! Redirecting you…",
+      errorTitle: "Error",
+      footer: {
+        noAccount: "Don’t have an account?",
+        signupLink: "Create one",
+      },
     },
   },
   router: {

--- a/src/shared/i18n/locales/it.ts
+++ b/src/shared/i18n/locales/it.ts
@@ -247,6 +247,28 @@ export const it = {
       passwordLabel: "Password",
       passwordShow: "Show",
       passwordHide: "Hide",
+      footer: {
+        haveAccount: "Hai già un account?",
+        loginLink: "Accedi",
+      },
+    },
+    login: {
+      badge: "Auth · Sign in",
+      title: "Accedi al tuo account",
+      description: "Inserisci le credenziali per continuare.",
+      processing: "Accesso in corso…",
+      fields: {
+        email: "Email",
+        password: "Password",
+      },
+      submit: "Accedi",
+      successTitle: "Accesso riuscito",
+      successBody: "Bentornato! Ti reindirizzo…",
+      errorTitle: "Errore",
+      footer: {
+        noAccount: "Non hai un account?",
+        signupLink: "Crea un account",
+      },
     },
   },
   router: {

--- a/src/shared/i18n/locales/sq.ts
+++ b/src/shared/i18n/locales/sq.ts
@@ -21,6 +21,7 @@ export const sq = {
       receiveUpdates: "Merr njoftime",
       clearFilters: "Hiq filtrat",
       logout: "Dil",
+      goBack: "Kthehu në faqen kryesore",
     },
     status: {
       publication: "Publikim",
@@ -248,6 +249,28 @@ export const sq = {
       passwordLabel: "Fjalëkalimi",
       passwordShow: "Shfaq",
       passwordHide: "Fshih",
+      footer: {
+        haveAccount: "Ke tashmë një llogari?",
+        loginLink: "Hyr",
+      },
+    },
+    login: {
+      badge: "Auth · Sign in",
+      title: "Hyr në llogarinë tënde",
+      description: "Shkruaj kredencialet për të vazhduar.",
+      processing: "Po identifikohemi…",
+      fields: {
+        email: "Email",
+        password: "Fjalëkalimi",
+      },
+      submit: "Hyr",
+      successTitle: "Identifikimi u krye",
+      successBody: "Mirë se u ktheve! Po të ridrejtojmë…",
+      errorTitle: "Gabim",
+      footer: {
+        noAccount: "Nuk ke ende një llogari?",
+        signupLink: "Krijo një",
+      },
     },
   },
   router: {


### PR DESCRIPTION
## Summary
- add a dedicated login screen that reuses shared auth form components, includes the language selector, and redirects after a successful backend call
- refactor signup to consume the shared auth utilities, add language/home controls, and update navigation/guards to link to the new login flow while tidying the in-app language switcher
- fix job-board filter reset behaviour and expand locale files with the new auth texts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfbdd72760832c83fbcb4ea7c6dfdb